### PR TITLE
Move deletion of test output files and folders to setUp-methods

### DIFF
--- a/hdl_reuse/test/functional/test_building_vivado_project.py
+++ b/hdl_reuse/test/functional/test_building_vivado_project.py
@@ -80,6 +80,9 @@ create_clock -period 5 -name clk_out [get_ports clk_out]
 """
 
     def setUp(self):
+        delete(self.modules_folder)
+        delete(self.project_folder)
+
         self.top = self.top_template.format(assign_output=self.resync)  # Default top level
 
         create_file(self.top_file, self.top)
@@ -91,10 +94,6 @@ create_clock -period 5 -name clk_out [get_ports clk_out]
         self.proj.create(self.project_folder)
 
         self.log_file = join(self.project_folder, "vivado.log")
-
-    def tearDown(self):
-        delete(self.modules_folder)
-        delete(self.project_folder)
 
     def test_create_project(self):
         pass

--- a/hdl_reuse/test/lint/test_python_lint.py
+++ b/hdl_reuse/test/lint/test_python_lint.py
@@ -45,10 +45,8 @@ cc  = 3
 """
 
     def setUp(self):
-        create_file(self.file, self.ugly_code)
-
-    def tearDown(self):
         delete(self.file)
+        create_file(self.file, self.ugly_code)
 
     def test_pylint_should_raise_exception_if_there_are_ugly_files(self):
         with pytest.raises(subprocess.CalledProcessError):

--- a/hdl_reuse/test/unit/test_constraints.py
+++ b/hdl_reuse/test/unit/test_constraints.py
@@ -14,10 +14,8 @@ class TestConstraint(unittest.TestCase):
     _modules_folder = join(THIS_DIR, "modules_for_test")
 
     def setUp(self):
-        self.file = create_file(join(self._modules_folder, "a", "entity_constraints", "apa.tcl"))
-
-    def tearDown(self):
         delete(self._modules_folder)
+        self.file = create_file(join(self._modules_folder, "a", "entity_constraints", "apa.tcl"))
 
     def test_constraint(self):
         constraint = Constraint(self.file)

--- a/hdl_reuse/test/unit/test_module.py
+++ b/hdl_reuse/test/unit/test_module.py
@@ -54,12 +54,10 @@ class TestGetModules(unittest.TestCase):
     _modules_folders = [_modules_folder]
 
     def setUp(self):
+        delete(self._modules_folder)
         create_directory(join(self._modules_folder, "a"))
         create_directory(join(self._modules_folder, "b"))
         create_directory(join(self._modules_folder, "c"))
-
-    def tearDown(self):
-        delete(self._modules_folder)
 
     def test_name_filtering(self):
         modules = get_modules(self._modules_folders, ["a", "b"])

--- a/hdl_reuse/test/unit/test_vivado_project.py
+++ b/hdl_reuse/test/unit/test_vivado_project.py
@@ -16,15 +16,14 @@ class TestBasicProject(unittest.TestCase):
     modules_folder = join(THIS_DIR, "modules")
 
     def setUp(self):
+        delete(self.modules_folder)
+        delete(self.project_folder)
+
         self.b_vhd = create_file(join(self.modules_folder, "apa", "b.vhd"))
         self.b_tcl = create_file(join(self.modules_folder, "apa", "entity_constraints", "b.tcl"))
 
         self.modules = get_modules([self.modules_folder])
         self.proj = VivadoProject(name="name", modules=self.modules, part="part")
-
-    def tearDown(self):
-        delete(self.modules_folder)
-        delete(self.project_folder)
 
     def test_constraints(self):
         b_tcl_found = False

--- a/hdl_reuse/test/unit/test_vivado_tcl.py
+++ b/hdl_reuse/test/unit/test_vivado_tcl.py
@@ -14,6 +14,8 @@ class TestVivadoTcl(unittest.TestCase):
     modules_folder = join(THIS_DIR, "modules")
 
     def setUp(self):
+        delete(self.modules_folder)
+
         # A library with some synth files and some test files
         self.a_vhd = create_file(join(self.modules_folder, "apa", "a.vhd"))
         self.tb_a_vhd = create_file(join(self.modules_folder, "apa", "test", "tb_a.vhd"))
@@ -25,9 +27,6 @@ class TestVivadoTcl(unittest.TestCase):
 
         self.modules = get_modules([self.modules_folder])
         self.tcl = VivadoTcl(name="name", modules=self.modules, part="part", top="top", constraints=[])
-
-    def tearDown(self):
-        delete(self.modules_folder)
 
     def test_only_synthesis_files_added_to_create_project_tcl(self):
         tcl = self.tcl.create(project_folder="")


### PR DESCRIPTION
The reason for this change is that tearDown is not run if test fails with an un-caught exception, causing the test to fail forever because test folders are not removed.

As a side-effect of this commit, all tearUp-methods have been removed.